### PR TITLE
Corrects a small typo in the docs for DAEAPI_wrapper

### DIFF
--- a/DAEAPI/DAEs/DAEAPI_Wrapper/0-README
+++ b/DAEAPI/DAEs/DAEAPI_Wrapper/0-README
@@ -21,7 +21,7 @@ How to build DAEAPI with DAEAPI wrapper:
 		DAE = add_to_DAE(DAE, 'field_name', field_value);
 	   to augment the skeleton structure.
 	3. Use
-		DAE = end_DAE(DAE);
+		DAE = finish_DAE(DAE);
 	   to finish constructing;
 
 Demo: How to use DAEAPI wrapper to build DAEAPI for an simple RC line circuit

--- a/help/DAEAPI_wrapper.m
+++ b/help/DAEAPI_wrapper.m
@@ -13,7 +13,7 @@
 %	    DAE = add_to_DAE(DAE, 'field_name', field_value);
 %   statements to augment the skeleton structure.
 %3. Finally, end with
-%	    DAE = end_DAE(DAE);
+%	    DAE = finish_DAE(DAE);
 %
 %help add_to_DAE for more information and examples.  
 %


### PR DESCRIPTION
DAEAPI_wrapper in explaining how to use it includes the wrong function name. `finish_DAE` should be used to finish generating the DAE object, docs currently refer to `end_DAE` a non-existent function.

This pull request replaces all instances of `end_DAE` with `finish_DAE`